### PR TITLE
Fix Typo in `validate.js`

### DIFF
--- a/src/validate.js
+++ b/src/validate.js
@@ -20,7 +20,7 @@ export function validateSolanaAddress(address) {
       throw new Error('Invalid length for a Solana address.');
     }
 
-    // TODO: finish validation for solana addres
+    // TODO: finish validation for solana address
     // // Convert the decoded address to a PublicKey object
     // const publicKey = new PublicKey(decoded);
     //


### PR DESCRIPTION
# Fix Typo in `validate.js`

## Description
This pull request resolves a typo in the `validate.js` file.  
- Corrected the spelling of "addres" to "address" in the TODO comment.

### Changes Made:
- **File Modified:** `src/validate.js`
- **Summary of Changes:**
  - Line 20: Corrected "addres" to "address."

## Related Issues
<!-- If applicable, link to any issues this PR addresses. -->
N/A

## Checklist
- [x] Code comments updated for clarity and professionalism.
- [x] Verified adherence to the project's [Contributing Guidelines](link-to-guidelines).

## Testing
<!-- Describe how you validated the change, if applicable. -->
- N/A (Comment typo fix only)

## Additional Notes
This update is a non-functional change and is strictly related to improving the clarity and accuracy of the comments.

---

**Allow edits by maintainers:** [x]  
<!-- Check this box to allow maintainers to modify the pull request if needed. -->
